### PR TITLE
Remove the redundant References section

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 1
-slug: /references/glossary
+sidebar_position: 5
+slug: /glossary
 title: Glossary
 ---
 

--- a/docs/references/_category_.json
+++ b/docs/references/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "References",
-  "position": 3
-}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,6 +73,10 @@ const config = {
                 label: "Game Mechanics",
                 to: "/game-mechanics",
               },
+              {
+                label: "Glossary",
+                to: "/glossary",
+              },
             ],
           },
           {


### PR DESCRIPTION
I don't know anything else to put there, since the file formats specification warrants a separate category.