### PR TITLE
Rename the npm format check script to make it easier to remember

### DIFF
--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -29,4 +29,4 @@ jobs:
         run: npm install --also=dev
 
       - name: Check for inconsistent formatting
-        run: npm run check-format
+        run: npm run format-check

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "linter": "npx eslint --cache \"**/*.{js,ts}\"",
-    "check-format": "npx prettier --check .",
+    "format-check": "npx prettier --check .",
     "autoformat": "npx prettier --write .",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",


### PR DESCRIPTION
This is more consistent with how reading out the commands would sound.