### PR TITLE
Add a basic Table of Contents page

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -6,8 +6,8 @@ const FeatureList = [
   {
     title: "Browse the Docs",
     bannerImage: "./img/hero_banner_book.png",
-    actionableLink: "View Documentation ➤",
-    actionableLinkTarget: "./documentation/",
+    actionableLink: "Table of Contents ➤",
+    actionableLinkTarget: "./contents/",
     description: (
       <>
         Read about file formats and other topics to learn more about the inner

--- a/src/pages/contents.md
+++ b/src/pages/contents.md
@@ -1,0 +1,17 @@
+---
+slug: /contents
+---
+
+# Table of Contents
+
+|                        Your goal                        |                                                           Where you should go                                                            |
+| :-----------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------: |
+| Understand what this website is about and why it exists |                                                          [About Page](/about/)                                                           |
+| Learn about various file formats used by the RO client  |                                                      [File Formats](/file-formats/)                                                      |
+|   Gain a better idea of how the 3D world is rendered    |                                                         [Rendering](/rendering/)                                                         |
+| Discover how the game servers might work under the hood |                                                    [Game Mechanics](/game-mechanics/)                                                    |
+|    Report an issue, give feedback, or ask questions     | [GitHub Issues](https://github.com/RagnarokResearchLab/ragnarokresearchlab.github.io/issues) or [Discord](https://discord.gg/7RFdMNrySy) |
+|  Delve into the fascinating history of RO's precursor   |                                                          [Arcturus](/arcturus/)                                                          |
+|                Contribute to the project                |                                                   [Contribution Guide](/contributing/)                                                   |
+
+Didn't find what you're looking for? Feel free to [open an issue](https://github.com/RagnarokResearchLab/ragnarokresearchlab.github.io/issues/new), or [join the Discord server](https://discord.gg/7RFdMNrySy)!


### PR DESCRIPTION
This is mostly intended as a workaround because the landing page link is dead (no overview page exists).

It would be better to have some of the pages moved out of the hierarchy (about, glossary come to mind), then move this to the top of the actual documentation. And it should likely be a regular category/auto-generated, too? Oh well, maybe later.