### PR TITLE
Add placeholder stubs for many relevant file formats

### DIFF
--- a/docs/file-formats/ACT.md
+++ b/docs/file-formats/ACT.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/act
+title: ACT (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/EBM.md
+++ b/docs/file-formats/EBM.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/ebm
+title: EBM (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/EZV.md
+++ b/docs/file-formats/EZV.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/ezv
+title: EZV (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/GAT.md
+++ b/docs/file-formats/GAT.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 2
 slug: /file-formats/gat
 title: GAT Format Specification
 ---

--- a/docs/file-formats/GND.md
+++ b/docs/file-formats/GND.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 30
 slug: /file-formats/gnd
 title: GND Format Specification
 ---

--- a/docs/file-formats/GR2.md
+++ b/docs/file-formats/GR2.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 120
 slug: /file-formats/gr2
 title: GR2 (Placeholder)
 ---

--- a/docs/file-formats/GRF.md
+++ b/docs/file-formats/GRF.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/grf
+title: GRF (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/IMF.md
+++ b/docs/file-formats/IMF.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/imf
+title: IMF (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/INI.md
+++ b/docs/file-formats/INI.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/ini
+title: INI (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/LUB.md
+++ b/docs/file-formats/LUB.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/lub
+title: LUB (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/PAL.md
+++ b/docs/file-formats/PAL.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/pal
+title: PAL (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/RGZ.md
+++ b/docs/file-formats/RGZ.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/RGZ
+title: RGZ (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/RMA.md
+++ b/docs/file-formats/RMA.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/rma
+title: RMA (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/RSA.md
+++ b/docs/file-formats/RSA.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/rsa
+title: RSA (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/RSM.md
+++ b/docs/file-formats/RSM.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 100
 slug: /file-formats/rsm
 title: RSM (Placeholder)
 ---

--- a/docs/file-formats/RSX.md
+++ b/docs/file-formats/RSX.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/rsx
+title: RSX (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/SCR.md
+++ b/docs/file-formats/SCR.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/scr
+title: SCR (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/SPR.md
+++ b/docs/file-formats/SPR.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/spr
+title: SPR (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::

--- a/docs/file-formats/STR.md
+++ b/docs/file-formats/STR.md
@@ -1,0 +1,10 @@
+---
+slug: /file-formats/str
+title: STR (Placeholder)
+---
+
+:::info
+
+This section is a placeholder. If you know anything about the topic, please help fill it with content!
+
+:::


### PR DESCRIPTION
This allows linking to them from other docs without failing the CI, even if no documentation yet exists.