### PR TITLE
Remove the glossary link from the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,10 +104,6 @@ const config = {
                 label: "Game Mechanics",
                 to: "/game-mechanics",
               },
-              {
-                label: "Glossary",
-                to: "/glossary",
-              },
             ],
           },
           {


### PR DESCRIPTION
It's not really that important, and listing only the main categories makes the footer consistent with the navigation bar at the top of the page.