### PR TITLE
Remove redundant title text from the File Formats category

### DIFF
--- a/docs/file-formats/EBM.md
+++ b/docs/file-formats/EBM.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/ebm
-title: EBM Format Specification
+title: EBM
 ---
 
 This document describes the EBM file format used in the Ragnarok Online client.

--- a/docs/file-formats/GAT.md
+++ b/docs/file-formats/GAT.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/gat
-title: GAT Format Specification
+title: GAT
 ---
 
 This document describes the GAT file format used in the Ragnarok Online client.

--- a/docs/file-formats/GND.md
+++ b/docs/file-formats/GND.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/gnd
-title: GND Format Specification
+title: GND
 ---
 
 This document describes the GND file format used in the Ragnarok Online client.

--- a/docs/file-formats/GR2.md
+++ b/docs/file-formats/GR2.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/gr2
-title: GR2 Format Specification
+title: GR2
 ---
 
 This document describes the GR2 file format used in the Ragnarok Online client.

--- a/docs/file-formats/GRF.md
+++ b/docs/file-formats/GRF.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/grf
-title: GRF Format Specification
+title: GRF
 ---
 
 This document describes the GRF file format used in the Ragnarok Online client.

--- a/docs/file-formats/PAL.md
+++ b/docs/file-formats/PAL.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/pal
-title: PAL Format Specification
+title: PAL
 ---
 
 This document describes the PAL file format used in the Ragnarok Online client.

--- a/docs/file-formats/RSW.md
+++ b/docs/file-formats/RSW.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/rsw
-title: RSW Format Specification
+title: RSW
 ---
 
 This document describes the RSW file format used in the Ragnarok Online client.

--- a/docs/file-formats/SPR.md
+++ b/docs/file-formats/SPR.md
@@ -1,6 +1,6 @@
 ---
 slug: /file-formats/spr
-title: SPR Format Specification
+title: SPR
 ---
 
 This document describes the SPR file format used in the Ragnarok Online client (and Arcturus).


### PR DESCRIPTION
Not sure it adds anything of value here.