### PR TITLE
Enable syntax highlighting for several useful languages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -154,6 +154,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ["c", "cpp", "lua", "rust", "wgsl"],
       },
     }),
 };


### PR DESCRIPTION
Syntax highlighting for most languages isn't enabled by default.