### PR TITLE
Implement diff views for the SPR specification

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -155,6 +155,18 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
         additionalLanguages: ["c", "cpp", "lua", "rust", "wgsl"],
+        magicComments: [
+          {
+            className: "code-block-diff-add-line",
+            line: "diff-add",
+            block: { start: "diff-add-start", end: "diff-add-end" },
+          },
+          {
+            className: "code-block-diff-remove-line",
+            line: "diff-remove",
+            block: { start: "diff-remove-start", end: "diff-remove-end" },
+          },
+        ],
       },
     }),
 };

--- a/src/css/color-theme-dark.css
+++ b/src/css/color-theme-dark.css
@@ -64,3 +64,32 @@ code {
   font-size: 85%;
   border: none;
 }
+
+/* Prism.js: Better syntax highlighting for important language keywords */
+span.token.keyword {
+  color: blue !important;
+  font-weight: bold;
+}
+
+span.token.class-name {
+  color: rgb(255, 0, 0) !important;
+}
+
+/* Prism.js: Magic comments for diff highlights */
+.code-block-diff-add-line {
+  background-color: #ccffd8;
+  background-color: rgb(230, 255, 235);
+  background-color: rgb(220, 255, 225);
+  display: block;
+  margin: 0 calc(var(--ifm-pre-padding) * -1);
+  padding: 0 var(--ifm-pre-padding);
+}
+
+.code-block-diff-remove-line {
+  background-color: #ffebe9;
+  background-color: rgb(255, 235, 235);
+  background-color: rgb(255, 225, 225);
+  display: block;
+  margin: 0 calc(var(--ifm-pre-padding) * -1);
+  padding: 0 var(--ifm-pre-padding);
+}


### PR DESCRIPTION
This cuts down a lot on redundancy and verbosity, while hopefully still providing all of the same information. It's mostly a test for the diff views; if this works out then the other format specifications can be reworked as well. Also added some reference implementations that are reasonably easy to understand (omitting the Unity ones because they aren't suitable for this purpose).

---

Resolves #86.